### PR TITLE
Dialog reply inserted into correct state.

### DIFF
--- a/thalan/thalan.tp2
+++ b/thalan/thalan.tp2
@@ -231,7 +231,7 @@ ACTION_IF !GAME_IS totsc BEGIN
     END
     
   ACTION_IF GAME_IS ~eet bgee~ BEGIN
-    APPEND_OUTER ~thalan/dlg/thalan.d~ ~~~~~EXTEND_TOP %tutu_var%THALAN 7 #1 IF ~Global("RumorTalkThalan","GLOBAL",1)~ THEN REPLY @8 GOTO s#tal02 END~~~~~
+    APPEND_OUTER ~thalan/dlg/thalan.d~ ~~~~~EXTEND_TOP %tutu_var%THALAN 1 #1 IF ~Global("RumorTalkThalan","GLOBAL",1)~ THEN REPLY @8 GOTO s#tal02 END~~~~~
   END
   
   //Dialogue


### PR DESCRIPTION
Another fix for commit d138761e8
In a clean BGEE install, THALAN.dlg state 7 is a branch about Melicamp.

```

IF ~~ THEN BEGIN 7 // from: 1.4
  SAY #6155 /* ~Chickens do not talk, so quite obviously it is a polymorphed being of some kind. Spells such as that wear off in time or can be dispelled. 'Tis a simple matter and one not worth the waste of my day. Keep moving.~ */
  IF ~~ THEN REPLY #6156 /* ~I am quite aware of the mute status of chickens, thank you very much! Yes, this is a transformed man, but it is also a man who claims to be your apprentice. That is why I brought him here.~ */ GOTO 9
  IF ~~ THEN REPLY #6157 /* ~There is no call to be so rude. Why are you so reluctant to deal with me?~ */ GOTO 8
  IF ~~ THEN REPLY #6162 /* ~Spare me your sanctimonious tone, old mage. I have brought this man here and now will leave you be.~ */ GOTO 10
END

```


Inserting that reply into state 1 instead of 7 fixes the issue - now you can ask about upgrades from the same state same as access the store.